### PR TITLE
(Re)add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,16 @@ script:
   # Check the role/playbook's syntax.
   - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
 
+  # Run the role/playbook with ansible-playbook.
+  - ansible-playbook -i tests/inventory tests/test.yml -vvvv
+
+  # Run the role/playbook again, checking to make sure it's idempotent.
+  - >
+    ansible-playbook -i tests/inventory tests/test.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
 notifications:
   email: false
   hipchat:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -9,7 +9,7 @@ docker_dependencies:
 docker_apt_https_transport_file: /usr/lib/apt/methods/https
 docker_apt_key:
   - id: A88D21E9
-    url: https://get.docker.com/gpg
+    url: http://get.docker.com/gpg
 docker_repository:
   - type: deb
     url: "https://get.docker.com/ubuntu docker"


### PR DESCRIPTION
Now that the tests run on trusty, it should be possible to install docker without the need for a reboot